### PR TITLE
Add support for gitlab todos

### DIFF
--- a/README.org
+++ b/README.org
@@ -92,6 +92,7 @@ Here is a quick rundown of features ~lab.el~ provides. I've included entry funct
     - Show detailed information about given job.
 - TODOs ::
   - List all TODOs for current user
+  - Mark all TODOs as done
   - Act on TODOs:
     - Open them in browser.
     - Mark as done.  

--- a/README.org
+++ b/README.org
@@ -90,6 +90,11 @@ Here is a quick rundown of features ~lab.el~ provides. I've included entry funct
     - Trigger retries, cancellation or deletion.
     - Show logs of a job on a nicely formatted buffer.
     - Show detailed information about given job.
+- TODOs ::
+  - List all TODOs for current user
+  - Act on TODOs:
+    - Open them in browser.
+    - Mark as done.  
 
 Here are few screenshots to get a feel of what you would see while using ~lab.el~:
 

--- a/lab.el
+++ b/lab.el
@@ -1257,9 +1257,23 @@ Main branch is one the branch names listed in `lab-main-branch-name'."
        (lab--inspect-obj it))))
 
 (defun lab--format-todo (todo)
-  (format "%s: %s"
-          (propertize (alist-get 'state todo) 'face '(:weight bold))
-          (alist-get 'body todo)))
+  (let* ((time (lab--time-ago (date-to-time (alist-get 'created_at todo))))
+         (person (alist-get 'username (alist-get 'author todo)))
+         (type (alist-get 'target_type todo))
+         (project-name (alist-get 'name (alist-get 'project todo)))
+         (group-name (alist-get 'name (alist-get 'group todo)))
+         (title (alist-get 'title (alist-get 'target todo)))
+         (name (pcase type
+                 ("Issue" (format "%s#%s" project-name title))
+                 ("MergeRequest" (format "%s!%s" project-name title))
+                 ("Epic" (format "%s/%s" group-name title))
+                 (_ title))))
+    (format "%-15s: %s@%s:%s %s"
+            time
+            (propertize person 'face '(:weight thin :slant italic))
+            (alist-get 'target_type todo)
+            (propertize name 'face 'bold)
+            (alist-get 'body todo))))
 
 (defun lab-list-todos ()
   "List all todos for current user."

--- a/lab.el
+++ b/lab.el
@@ -1243,6 +1243,29 @@ Main branch is one the branch names listed in `lab-main-branch-name'."
     (map-insert yaml-data
                 :description (s-trim (buffer-substring-no-properties (point) (point-max))))))
 
+;; TODOs:
+
+(lab--define-actions-for todo
+  :formatter #'lab--format-todo
+  :keymap
+  ((?o "Open"
+       (lab--open-web-url .target_url))
+   (?d "Mark as done" (lab--request
+                       (format "todos/%s/mark_as_done" .id)
+                       :%type "POST"))
+   (?i "Inspect"
+       (lab--inspect-obj it))))
+
+(defun lab--format-todo (todo)
+  (format "%s: %s"
+          (propertize (alist-get 'state todo) 'face '(:weight bold))
+          (alist-get 'body todo)))
+
+(defun lab-list-todos ()
+  "List all todos for current user."
+  (interactive)
+  (lab-todo-select-and-act-on
+   (lab--request "todos")))
 
 ;;; Formatters & other helpers:
 

--- a/lab.el
+++ b/lab.el
@@ -123,7 +123,7 @@ Can't be higher than `lab--max-per-page-result-count'."
   'ssh
   "Prefered for cloning repositories into your local."
   :type '(choice (const :tag "SSH" ssh)
-                 (const :tag "HTTPS" https))
+          (const :tag "HTTPS" https))
   :group 'lab)
 
 (defcustom lab-action-handler
@@ -132,7 +132,7 @@ Can't be higher than `lab--max-per-page-result-count'."
 `lab' uses the given function for listing possible actions on a
 selection."
   :type '(choice (const :tag "completing-read" completing-read)
-                 (const :tag "read-multiple-choice" read-multiple-choice))
+          (const :tag "read-multiple-choice" read-multiple-choice))
   :group 'lab)
 
 (defcustom lab-main-branch-name
@@ -455,12 +455,12 @@ function is called if given and the buffer is simply killed."
 (defmacro lab--within-current-project (&rest forms)
   "Let you run FORMS in current projects directory."
   `(let ((default-directory
-           (or
-            (when (boundp 'project-current-inhibit-prompt)
-              project-current-inhibit-prompt)
-            (when (boundp 'project-current-directory-override)
-              project-current-directory-override)
-            default-directory)))
+          (or
+           (when (boundp 'project-current-inhibit-prompt)
+             project-current-inhibit-prompt)
+           (when (boundp 'project-current-directory-override)
+             project-current-directory-override)
+           default-directory)))
      ,@forms))
 
 (defun lab--find-all-repositories-under (path)
@@ -1273,7 +1273,6 @@ Main branch is one the branch names listed in `lab-main-branch-name'."
   (lab--request
    "todos/mark_as_done"
    :%type "POST"))
-
 
 ;;; Formatters & other helpers:
 

--- a/lab.el
+++ b/lab.el
@@ -1266,6 +1266,14 @@ Main branch is one the branch names listed in `lab-main-branch-name'."
   (interactive)
   (lab-todo-select-and-act-on
    (lab--request "todos")))
+
+(defun lab-mark-done-all-todos ()
+  "Mark all todos as done."
+  (interactive)
+  (lab--request
+   "todos/mark_as_done"
+   :%type "POST"))
+
 
 ;;; Formatters & other helpers:
 


### PR DESCRIPTION
Api description is here: https://docs.gitlab.com/ee/api/todos.html#mark-a-to-do-item-as-done

Supports opening, marking as done and inspect , and marking all todos as done

This is example of how the list of looks. 
![CleanShot 2024-03-01 at 22 45 08@2x](https://github.com/isamert/lab.el/assets/294522/ab7d7c79-fe56-4a00-b98a-60daa139e5ce)
