### PR TITLE
select-and-act-on: Select the sole item when n=1

### DIFF
--- a/lab.el
+++ b/lab.el
@@ -570,12 +570,14 @@ function is called if given and the buffer is simply killed."
 
        (cl-defun ,(funcall lab--generate-action-name category "select-and-act-on" t) (items)
          (ignore-error (quit minibuffer-quit)
-           (let* ((result (lab--completing-read-object
-                           (format "%s: " (s-titleize (format "%s" ',category)))
-                           items
-                           :formatter ,formatter
-                           :category ',lab-category-full-name
-                           :sort? ,sort?)))
+           (let* ((result (if (eq (length items) 1)
+                              (car items)
+                            (lab--completing-read-object
+                             (format "%s: " (s-titleize (format "%s" ',category)))
+                             items
+                             :formatter ,formatter
+                             :category ',lab-category-full-name
+                             :sort? ,sort?))))
              (funcall #',(funcall lab--generate-action-name category "act-on" t) result)))))))
 
 (defvar project-current-inhibit-prompt)


### PR DESCRIPTION
Makes working with items more speedy. No need to select when there’s only one option!
Cheers, I love this project, use it daily.